### PR TITLE
remove need for polymer-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ To work on the proof-of-concept implementation, ensure you have installed the np
 
 ```sh
 $ npm install
-$ polymer serve --npm
+$ python -m SimpleHTTPServer 8081
 ```
 
-Then, navigate to the url: http://localhost:8081/components/virtual-list/
+Then, navigate to the url: http://localhost:8081/
 
 For more documentation on the internal pieces that we use to implement our `<virtual-list>` prototype, see [DESIGN.md](./DESIGN.md).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The (tentative) API design choices made here, as well as the list's capabilities
 </script>
 ```
 
+Checkout more examples in [demo/index.html](./demo/index.html) and [demo/examples.html](demo/examples.html).
+
 ## API
 
 ### `newChild` property

--- a/README.md
+++ b/README.md
@@ -177,6 +177,6 @@ $ npm install
 $ python -m SimpleHTTPServer 8081
 ```
 
-Then, navigate to the url: http://localhost:8081/
+Then, navigate to the url: http://localhost:8081/demo/
 
 For more documentation on the internal pieces that we use to implement our `<virtual-list>` prototype, see [DESIGN.md](./DESIGN.md).

--- a/demo/basic-repeat/lit-html/basic-repeat.js
+++ b/demo/basic-repeat/lit-html/basic-repeat.js
@@ -1,5 +1,5 @@
-import {html, render} from '../../../../lit-html/lib/lit-extended.js';
 import {repeat} from '../../../lit-html/lit-repeater.js';
+import {html, render} from '../../../node_modules/lit-html/lib/lit-extended.js';
 import {Sample as BaseSample} from '../basic-repeat.js';
 
 export class Sample extends BaseSample {

--- a/demo/basic-repeat/preact/basic-repeat.js
+++ b/demo/basic-repeat/preact/basic-repeat.js
@@ -1,4 +1,4 @@
-import {Component, h, render} from '../../../../preact/dist/preact.esm.js';
+import {Component, h, render} from '../../../node_modules/preact/dist/preact.esm.js';
 import {Repeat} from '../../../preact/preact-repeater.js';
 import {RepeaterControl} from '../basic-repeat.js';
 

--- a/demo/basic-repeat/preact/index.html
+++ b/demo/basic-repeat/preact/index.html
@@ -9,13 +9,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <!doctype html>
 <html>
-  <head>
-    <script type="module">
-      import {Sample} from './basic-repeat.js';
-      import {render, h} from '../../../../preact/dist/preact.esm.js';
-      render(h(Sample), document.body);
-    </script>
-  </head>
-  <body>
-  </body>
+
+<head>
+  <script type="module">
+    import { Sample } from './basic-repeat.js';
+    import { render, h } from '../../../node_modules/preact/dist/preact.esm.js';
+    render(h(Sample), document.body);
+  </script>
+</head>
+
+<body>
+</body>
+
 </html>

--- a/demo/contacts/lit-html/contacts.js
+++ b/demo/contacts/lit-html/contacts.js
@@ -1,5 +1,5 @@
-import {html, render} from '../../../../lit-html/lib/lit-extended.js';
 import {list} from '../../../lit-html/lit-list.js';
+import {html, render} from '../../../node_modules/lit-html/lib/lit-extended.js';
 import {itemType, Sample as BaseSample} from '../contacts.js';
 
 export class Sample extends BaseSample {

--- a/demo/contacts/preact/contacts.js
+++ b/demo/contacts/preact/contacts.js
@@ -1,4 +1,4 @@
-import {h, render} from '../../../../preact/dist/preact.esm.js';
+import {h, render} from '../../../node_modules/preact/dist/preact.esm.js';
 import {List} from '../../../preact/preact-list.js';
 import {itemType, Sample as BaseSample} from '../contacts.js';
 

--- a/demo/html-spec/html-spec-viewer.js
+++ b/demo/html-spec/html-spec-viewer.js
@@ -1,5 +1,5 @@
-import {HtmlSpec} from '../../../streaming-spec/HtmlSpec.js';
-import {iterateStream} from '../../../streaming-spec/iterateStream.js';
+import {HtmlSpec} from '../../node_modules/streaming-spec/HtmlSpec.js';
+import {iterateStream} from '../../node_modules/streaming-spec/iterateStream.js';
 import {VirtualListElement} from '../../virtual-list-element.js';
 
 class HTMLSpecViewer extends VirtualListElement {

--- a/demo/incremental-repeat/lit-html/lit-incremental-list.js
+++ b/demo/incremental-repeat/lit-html/lit-incremental-list.js
@@ -1,5 +1,5 @@
-import {html, render} from '../../../../lit-html/lib/lit-extended.js';
 import {repeat} from '../../../lit-html/lit-incremental-repeater.js';
+import {html, render} from '../../../node_modules/lit-html/lib/lit-extended.js';
 
 class LitIncrementalListElement extends HTMLElement {
   constructor() {

--- a/demo/photos/lit-html/photos.js
+++ b/demo/photos/lit-html/photos.js
@@ -1,5 +1,5 @@
-import {html, render} from '../../../../lit-html/lib/lit-extended.js';
 import {list} from '../../../lit-html/lit-list.js';
+import {html, render} from '../../../node_modules/lit-html/lib/lit-extended.js';
 import {getDims, getUrl, Sample as BaseSample} from '../photos.js';
 
 export class Sample extends BaseSample {

--- a/demo/photos/preact/photos.js
+++ b/demo/photos/preact/photos.js
@@ -1,4 +1,4 @@
-import {h, render} from '../../../../preact/dist/preact.esm.js';
+import {h, render} from '../../../node_modules/preact/dist/preact.esm.js';
 import {List} from '../../../preact/preact-list.js';
 import {getDims, getUrl, Sample as BaseSample} from '../photos.js';
 

--- a/deploy-to-gh-pages.sh
+++ b/deploy-to-gh-pages.sh
@@ -49,8 +49,7 @@ find node_modules/$repo -name '*.js' -exec sed -i '' 's/node_modules\//component
 mv node_modules/$repo .
 rm -rf node_modules/
 
-# redirect by default to the component folder
-echo "<META http-equiv=\"refresh\" content=\"0;URL=./demo/\">" > index.html
+# Allow github to use README.md as main page.
 
 # send it all to github
 git add -A .

--- a/deploy-to-gh-pages.sh
+++ b/deploy-to-gh-pages.sh
@@ -44,11 +44,13 @@ mkdir components
 mv node_modules/lit-html components/
 mv node_modules/preact components/
 mv node_modules/streaming-spec components/
-mv node_modules/$repo components/
+# replace node_modules/ with components/
+find node_modules/$repo -name '*.js' -exec sed -i '' 's/node_modules\//components\//g' {} \;
+mv node_modules/$repo .
 rm -rf node_modules/
 
 # redirect by default to the component folder
-echo "<META http-equiv=\"refresh\" content=\"0;URL=components/$repo/demo\">" > index.html
+echo "<META http-equiv=\"refresh\" content=\"0;URL=./demo/\">" > index.html
 
 # send it all to github
 git add -A .

--- a/lit-html/lit-incremental-repeater.js
+++ b/lit-html/lit-incremental-repeater.js
@@ -1,5 +1,5 @@
-import {directive} from '../../lit-html/lit-html.js';
 import {IncrementalRepeater} from '../incremental-repeater.js';
+import {directive} from '../node_modules/lit-html/lit-html.js';
 
 import {LitMixin} from './lit-repeater.js';
 

--- a/lit-html/lit-list.js
+++ b/lit-html/lit-list.js
@@ -1,5 +1,5 @@
-import {directive} from '../../lit-html/lit-html.js';
 import Layout from '../layouts/layout-1d.js';
+import {directive} from '../node_modules/lit-html/lit-html.js';
 import {VirtualList} from '../virtual-list.js';
 
 import {LitMixin} from './lit-repeater.js';

--- a/lit-html/lit-repeater.js
+++ b/lit-html/lit-repeater.js
@@ -1,4 +1,4 @@
-import {directive, NodePart} from '../../lit-html/lit-html.js';
+import {directive, NodePart} from '../node_modules/lit-html/lit-html.js';
 import {VirtualRepeater} from '../virtual-repeater.js';
 
 export const LitMixin = Superclass => class extends Superclass {

--- a/preact/preact-repeater.js
+++ b/preact/preact-repeater.js
@@ -1,4 +1,4 @@
-import {Component, h, render} from '../../preact/dist/preact.esm.js';
+import {Component, h, render} from '../node_modules/preact/dist/preact.esm.js';
 import {VirtualRepeater} from '../virtual-repeater.js';
 
 export class Repeat extends Component {

--- a/smoke/flat/script.js
+++ b/smoke/flat/script.js
@@ -1,6 +1,6 @@
-import {html, render} from '../../../lit-html/lib/lit-extended.js';
 import Layout from '../../layouts/layout-1d.js';
 import {list} from '../../lit-html/lit-list.js';
+import {html, render} from '../../node_modules/lit-html/lib/lit-extended.js';
 import {VirtualList} from '../../virtual-list.js';
 
 const items = new Array(200).fill({name: 'item'});

--- a/smoke/nested/script.js
+++ b/smoke/nested/script.js
@@ -1,6 +1,6 @@
-import {html, render} from '../../../lit-html/lit-html.js';
 import Layout from '../../layouts/layout-1d.js';
 import {list} from '../../lit-html/lit-list.js';
+import {html, render} from '../../node_modules/lit-html/lit-html.js';
 import {VirtualList} from '../../virtual-list.js';
 
 const items = new Array(40).fill({


### PR DESCRIPTION
Fixes https://github.com/valdrinkoshi/virtual-list/issues/28, suggest serving resources with a simple server (python because why not).
Also, update deploy script to allow README.md to be the main page when user navigates to https://valdrinkoshi.github.io/virtual-list/