### PR TITLE
demo/fallback.html

### DIFF
--- a/demo/contacts/contact-data-source.js
+++ b/demo/contacts/contact-data-source.js
@@ -1,0 +1,33 @@
+export class ContactDataSource {
+  constructor() {
+    this._delay = 1000;
+    this._allContacts = null;
+    this._loading = false;
+    this._loadedAll = false;
+  }
+  get loadedAll() {
+    return this._loadedAll;
+  }
+  get loading() {
+    return this._loading;
+  }
+  get delay() {
+    return this._delay;
+  }
+  set delay(delayMs) {
+    this._delay = delayMs;
+  }
+  async getContacts(count) {
+    this._loading = true;
+    if (!this._allContacts) {
+      this._allContacts =
+          await fetch('contacts/contacts.json').then(resp => resp.json());
+    }
+    // Simulate slow server load...
+    await new Promise(resolve => setTimeout(resolve, this._delay));
+    const res = this._allContacts.splice(0, count);
+    this._loadedAll = this._allContacts.length === 0;
+    this._loading = false;
+    return res;
+  }
+}

--- a/demo/contacts/contact-element.js
+++ b/demo/contacts/contact-element.js
@@ -1,0 +1,78 @@
+class ContactElement extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) {
+      return;
+    }
+    this.attachShadow({mode: 'open'}).innerHTML = `
+<style>
+  :host {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 1rem 0;
+    border-bottom: 1px solid #eee;
+    will-change: transform;
+  }
+  :host([sortable]) {
+    transition: transform 200ms ease-in-out;
+  }
+  img {
+    width: 50px;
+    height: 50px;
+    margin-right: 15px;
+    border-radius: 50%;
+    background-color: lightgray;
+  }
+  label {
+    width: 100%;
+    flex: 1;
+  }
+  button {
+    background-color: transparent;
+    border: none;
+    outline: none;
+  }
+  :host(:not([sortable])) #counter,
+  :host(:not([sortable])) button {
+    display: none;
+  }
+</style>
+<img id="img">
+<label id="label"></label>
+<span id="counter"></span>
+<button id="up">🔼</button>
+<button id="down">🔽</button>`;
+
+    this._img = this.shadowRoot.querySelector('#img');
+    this._label = this.shadowRoot.querySelector('label');
+    this._counter = this.shadowRoot.querySelector('#counter');
+    this._renderCount = 0;
+
+    const up = this.shadowRoot.querySelector('#up');
+    up.addEventListener('click', () => this.dispatchEvent(new Event('moveup')));
+    const down = this.shadowRoot.querySelector('#down');
+    down.addEventListener(
+        'click', () => this.dispatchEvent(new Event('movedown')));
+
+    this.contact && this._render();
+  }
+  get contact() {
+    return this._contact;
+  }
+  set contact(contact) {
+    if (contact !== this._contact) {
+      this._contact = contact;
+      this._render();
+    }
+  }
+  _render() {
+    if (!this.shadowRoot)
+      return;
+    const contact = this.contact || {};
+    this._img.src = contact.image;
+    this._label.textContent = contact.name;
+    this._label.style.color = contact.color;
+    this._counter.textContent = `render count: ${++this._renderCount}`;
+  }
+}
+customElements.define('contact-element', ContactElement);

--- a/demo/contacts/contact-element.js
+++ b/demo/contacts/contact-element.js
@@ -9,7 +9,8 @@ class ContactElement extends HTMLElement {
     display: flex;
     align-items: center;
     width: 100%;
-    padding: 1rem 0;
+    padding: 10px;
+    box-sizing: border-box;
     border-bottom: 1px solid #eee;
     will-change: transform;
   }
@@ -69,7 +70,9 @@ class ContactElement extends HTMLElement {
     if (!this.shadowRoot)
       return;
     const contact = this.contact || {};
-    this._img.src = contact.image;
+    if (contact.image) {
+      this._img.src = contact.image;
+    }
     this._label.textContent = contact.name;
     this._label.style.color = contact.color;
     this._counter.textContent = `render count: ${++this._renderCount}`;

--- a/demo/contacts/contact-element.js
+++ b/demo/contacts/contact-element.js
@@ -56,6 +56,11 @@ class ContactElement extends HTMLElement {
         'click', () => this.dispatchEvent(new Event('movedown')));
 
     this.contact && this._render();
+    // Animate only after the first render.
+    if (this.hasAttribute('sortable')) {
+      this.style.transition = 'none';
+      window.requestIdleCallback(() => this.style.transition = null);
+    }
   }
   get contact() {
     return this._contact;

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -71,7 +71,7 @@
 
     // Start with fallbacks, generate enough to cover the viewport height.
     const fallbacksCount = Math.ceil(virtualList.offsetHeight / 80);
-    virtualList.items = getFallbacks(fallbacksCount);
+    virtualList.items = createFallbacks(fallbacksCount);
 
     // Keep track of first fallback index to know when we need to load more contacts.
     let firstFallbackIndex = 0;
@@ -97,7 +97,7 @@
       virtualList.requestReset();
     }
 
-    function getFallbacks(count) {
+    function createFallbacks(count) {
       const fallbacks = [];
       for (let i = 0; i < count; i++) {
         fallbacks.push({

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -69,24 +69,28 @@
       element.contact = contact;
     };
 
-    // Start with fallbacks, generate enough to cover the viewport height.
+    // Generate enough fallbacks to cover the viewport height.
     const fallbacksCount = Math.ceil(virtualList.offsetHeight / 80);
-    virtualList.items = createFallbacks(fallbacksCount);
+    const items = new Array(fallbacksCount);
+    for (let i = 0; i < fallbacksCount; i++) {
+      items[i] = {
+        name: 'Loading...',
+        customAnimation: `inverse-color 1000ms ${i * 50}ms infinite`,
+      };
+    }
+    virtualList.items = items;
 
     // Keep track of first fallback index to know when we need to load more contacts.
     let firstFallbackIndex = 0;
-    virtualList.addEventListener('rangechange', (range) => {
-      if (range.last >= firstFallbackIndex) {
-        loadMore();
+    virtualList.addEventListener('rangechange', async (range) => {
+      if (dataSource.loading || dataSource.loadedAll || firstFallbackIndex > range.last) {
+        return;
       }
-    });
 
-    async function loadMore() {
-      if (dataSource.loading || dataSource.loadedAll) return;
       // Load 5x contacts so user has room to scroll once they're loaded.
       const newContacts = await dataSource.getContacts(fallbacksCount * 5);
       if (dataSource.loadedAll) {
-        // Remove fallbacks.
+        // Insert new contacts, remove fallbacks.
         virtualList.items.splice(firstFallbackIndex, fallbacksCount, ...newContacts);
         firstFallbackIndex = Infinity;
       } else {
@@ -95,21 +99,9 @@
         firstFallbackIndex += newContacts.length;
       }
       virtualList.requestReset();
-    }
+    });
 
-    function createFallbacks(count) {
-      const fallbacks = [];
-      for (let i = 0; i < count; i++) {
-        fallbacks.push({
-          name: 'Loading...',
-          image: null,
-          customAnimation: `inverse-color 1000ms ${i * 50}ms infinite`,
-        });
-      }
-      return fallbacks;
-    }
-
-    window.updateDelay = function updateDelay(delayEl) {
+    window.updateDelay = (delayEl) => {
       let delay = delayEl.valueAsNumber;
       if (Number.isNaN(delay)) {
         // Default.

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -53,14 +53,19 @@
     /**
      * 1. A fallback item has the same shape as a contact item, with an additional
      * field `customAnimation`.
-     * 2. Both fallbacks and contacts are represented with <contact-element>
-     * 3. We load more contacts when user scrolls to the end of the list
+     * 2. Both fallbacks and contacts are represented with <contact-element>.
+     * 3. We start with enough fallbacks to cover the viewport.
+     * 4. We load more contacts when user scrolls to the first fallback
      * (listen for `rangechange`)
+     * 5. Once all contacts are loaded, we can finally remove the fallbacks.
      */
 
     const dataSource = new ContactDataSource();
     const virtualList = document.querySelector('virtual-list');
-    const fallbacks = getFallbacks(virtualList.offsetHeight);
+    const fallbacks = getFallbacks({
+      elementHeight: 80,
+      viewportHeight: virtualList.offsetHeight
+    });
     let firstFallbackIndex = 0;
     let lastVisibleIndex = -1;
 
@@ -97,9 +102,7 @@
       }
     }
 
-    function getFallbacks(viewportHeight) {
-      // Compute how many <contact-element> can fit in the virtual-list height.
-      const elementHeight = 80;
+    function getFallbacks({ elementHeight, viewportHeight }) {
       // We want enough fallbacks to cover the viewport height.
       const count = Math.ceil(viewportHeight / elementHeight);
       const fallbacks = [];

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -11,9 +11,13 @@
       margin: 10px auto;
     }
 
-    .fallback::before {
-      content: 'Loading ...';
-      line-height: 50px;
+    fallback-element {
+      display: block;
+    }
+
+    fallback-element::before {
+      content: 'Loading...';
+      line-height: 80px;
     }
   </style>
 </head>
@@ -30,31 +34,33 @@
     import '../virtual-list-element.js';
     import './contacts/contact-element.js';
 
-    const virtualList = document.querySelector('virtual-list');
-
-    Object.assign(virtualList, {
-      newChild(contact) {
-        if (contact.fallback) {
-          const fallback = document.createElement('div');
-          fallback.classList.add('fallback');
-          return fallback;
-        }
-        return document.createElement('contact-element');
-      },
-      updateChild(element, contact) {
-        element.contact = contact;
-      },
-      itemKey(contact) {
-        return contact.guid;
-      }
-    });
-
-    const fallbackHeight = 50;
+    const fallbackHeight = 80;
     const fallbacks = [];
     for (let i = 0, l = Math.ceil(innerHeight / fallbackHeight) + 5; i < l; i++) {
       fallbacks.push({ fallback: true, guid: 'fallback' + i });
     }
-    virtualList.items = [...fallbacks];
+
+    const nodePool = {
+      'fallback-element': [],
+      'contact-element': []
+    };
+    const virtualList = document.querySelector('virtual-list');
+    Object.assign(virtualList, {
+      newChild(contact) {
+        const type = contact.fallback ? 'fallback-element' : 'contact-element';
+        return nodePool[type].pop() || document.createElement(type);
+      },
+      updateChild(element, contact) {
+        element.contact = contact;
+      },
+      recycleChild(element) {
+        nodePool[element.localName].push(element);
+      },
+      itemKey(contact) {
+        return contact.guid;
+      },
+      items: [...fallbacks]
+    });
 
     let delayMs = 1000;
     let isLoading = false;

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -13,20 +13,29 @@
 
     fallback-element {
       display: block;
+      width: 100%;
+      text-align: center;
+      line-height: 80px;
+      border-bottom: 1px solid #eee;
+      animation: inverse-color 1000ms infinite;
     }
 
-    fallback-element::before {
-      content: 'Loading...';
-      line-height: 80px;
+    @keyframes inverse-color {
+      50% {
+        background-color: #ddd;
+        color: white;
+      }
     }
   </style>
 </head>
 
 <body>
-  <label>
-    Server response time (ms):
-    <input type="number" value=1000 min=0 max=10000 onchange="updateDelay(this)">
-  </label>
+  <p>
+    <label>
+      Server response time (ms):
+      <input type="number" value=1000 min=0 max=10000 onchange="updateDelay(this)">
+    </label>
+  </p>
 
   <virtual-list></virtual-list>
 
@@ -35,10 +44,14 @@
     import './contacts/contact-element.js';
 
     const fallbackHeight = 80;
+    const fallbacksCount = Math.ceil(innerHeight / fallbackHeight) + 5;
     const fallbacks = [];
-    for (let i = 0, l = Math.ceil(innerHeight / fallbackHeight) + 5; i < l; i++) {
-      fallbacks.push({ fallback: true, guid: 'fallback' + i });
+    for (let i = 0; i < fallbacksCount; i++) {
+      fallbacks.push({ fallback: true, guid: 'fallback' + i, index: i });
     }
+
+    // Make a copy of the fallbacks.
+    const items = fallbacks.slice();
 
     const nodePool = {
       'fallback-element': [],
@@ -51,7 +64,12 @@
         return nodePool[type].pop() || document.createElement(type);
       },
       updateChild(element, contact) {
-        element.contact = contact;
+        if (contact.fallback) {
+          element.textContent = '... Loading ...';
+          element.style.animationDelay = (50 * contact.index) + 'ms';
+        } else {
+          element.contact = contact;
+        }
       },
       recycleChild(element) {
         nodePool[element.localName].push(element);
@@ -59,13 +77,15 @@
       itemKey(contact) {
         return contact.guid;
       },
-      items: [...fallbacks]
+      items,
     });
 
     let delayMs = 1000;
     let isLoading = false;
     let allContacts = null;
     loadMore();
+
+    window.updateDelay = updateDelay;
 
     async function loadMore() {
       if (isLoading) return;
@@ -75,14 +95,14 @@
 
       const newContacts = await getContacts();
 
-      const i = virtualList.items.indexOf(fallbacks[0]);
+      const i = items.length - fallbacksCount;
       if (newContacts.length) {
         // Keep fallbacks, insert newContacts.
-        virtualList.items.splice(i, 0, ...newContacts);
+        items.splice(i, 0, ...newContacts);
         virtualList.addEventListener('rangechange', onRangechange);
       } else {
         // Loaded all contacts! Remove fallbacks.
-        virtualList.items.splice(i, fallbacks.length);
+        items.splice(i, fallbacksCount);
       }
       virtualList.requestReset();
 
@@ -95,24 +115,26 @@
       }
       // Simulate slow server load...
       await new Promise(resolve => setTimeout(resolve, delayMs));
-      return allContacts.splice(0, fallbacks.length);
+      return allContacts.splice(0, fallbacksCount);
     }
 
     function onRangechange(range) {
-      const i = virtualList.items.indexOf(fallbacks[0]);
-      if (i >= 0 && range.last > i) {
+      if (range.last > items.length - fallbacksCount) {
         loadMore();
       }
     }
 
-    window.updateDelay = function updateDelay(delayEl) {
+    function updateDelay(delayEl) {
       delayMs = delayEl.valueAsNumber;
       if (Number.isNaN(delayMs)) {
         // Default.
         delayMs = 1000;
       } else {
         // Force min/max.
-        delayMs = Math.max(Number.parseInt(delayEl.min), Math.min(delayMs, Number.parseInt(delayEl.max)));
+        delayMs = Math.max(
+          Number.parseInt(delayEl.min),
+          Math.min(delayMs, Number.parseInt(delayEl.max))
+        );
       }
       delayEl.value = delayMs;
     };

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -1,0 +1,116 @@
+<html>
+
+<head>
+  <title>Fallback element</title>
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <style>
+    body {
+      font-family: Roboto, Helvetica, sans-serif;
+      max-width: 600px;
+      margin: 10px auto;
+    }
+
+    .fallback::before {
+      content: 'Loading ...';
+      line-height: 50px;
+    }
+  </style>
+</head>
+
+<body>
+  <label>
+    Server response time (ms):
+    <input type="number" value=1000 min=0 max=10000 onchange="updateDelay(this)">
+  </label>
+
+  <virtual-list></virtual-list>
+
+  <script type="module">
+    import '../virtual-list-element.js';
+    import './contacts/contact-element.js';
+
+    const virtualList = document.querySelector('virtual-list');
+
+    Object.assign(virtualList, {
+      newChild(contact) {
+        if (contact.fallback) {
+          const fallback = document.createElement('div');
+          fallback.classList.add('fallback');
+          return fallback;
+        }
+        return document.createElement('contact-element');
+      },
+      updateChild(element, contact) {
+        element.contact = contact;
+      },
+      itemKey(contact) {
+        return contact.guid;
+      }
+    });
+
+    const fallbackHeight = 50;
+    const fallbacks = [];
+    for (let i = 0, l = Math.ceil(innerHeight / fallbackHeight) + 5; i < l; i++) {
+      fallbacks.push({ fallback: true, guid: 'fallback' + i });
+    }
+    virtualList.items = [...fallbacks];
+
+    let delayMs = 1000;
+    let isLoading = false;
+    let allContacts = null;
+    loadMore();
+
+    async function loadMore() {
+      if (isLoading) return;
+      isLoading = true;
+
+      virtualList.removeEventListener('rangechange', onRangechange);
+
+      const newContacts = await getContacts();
+
+      const i = virtualList.items.indexOf(fallbacks[0]);
+      if (newContacts.length) {
+        // Keep fallbacks, insert newContacts.
+        virtualList.items.splice(i, 0, ...newContacts);
+        virtualList.addEventListener('rangechange', onRangechange);
+      } else {
+        // Loaded all contacts! Remove fallbacks.
+        virtualList.items.splice(i, fallbacks.length);
+      }
+      virtualList.requestReset();
+
+      isLoading = false;
+    }
+
+    async function getContacts() {
+      if (!allContacts) {
+        allContacts = await fetch('contacts/contacts.json').then(resp => resp.json());
+      }
+      // Simulate slow server load...
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      return allContacts.splice(0, fallbacks.length);
+    }
+
+    function onRangechange(range) {
+      const i = virtualList.items.indexOf(fallbacks[0]);
+      if (i >= 0 && range.last > i) {
+        loadMore();
+      }
+    }
+
+    window.updateDelay = function updateDelay(delayEl) {
+      delayMs = delayEl.valueAsNumber;
+      if (Number.isNaN(delayMs)) {
+        // Default.
+        delayMs = 1000;
+      } else {
+        // Force min/max.
+        delayMs = Math.max(Number.parseInt(delayEl.min), Math.min(delayMs, Number.parseInt(delayEl.max)));
+      }
+      delayEl.value = delayMs;
+    };
+  </script>
+</body>
+
+</html>

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -65,7 +65,7 @@
 
     virtualList.newChild = (contact) => document.createElement('contact-element');
     virtualList.updateChild = (element, contact) => {
-      element.style.animation = contact.customAnimation;
+      element.style.animation = contact.customAnimation || null;
       element.contact = contact;
     };
 

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -9,23 +9,21 @@
       font-family: Roboto, Helvetica, sans-serif;
       max-width: 600px;
       margin: 10px auto;
+      display: flex;
+      flex-direction: column;
     }
 
     virtual-list {
       width: 100%;
-      height: 50vh;
+      height: 100%;
+      flex: 1;
       margin: 10px 0;
       border-top: 2px solid #eee;
       border-bottom: 2px solid #eee;
     }
 
-    fallback-element {
-      display: block;
-      width: 100%;
-      text-align: center;
-      line-height: 80px;
-      border-bottom: 1px solid #eee;
-      animation: inverse-color 1000ms infinite;
+    contact-element {
+      height: 80px;
     }
 
     @keyframes inverse-color {
@@ -50,101 +48,85 @@
   <script type="module">
     import '../virtual-list-element.js';
     import './contacts/contact-element.js';
+    import { ContactDataSource } from './contacts/contact-data-source.js';
 
-    const fallbackHeight = 80;
-    const fallbacksCount = Math.ceil(innerHeight / fallbackHeight) + 5;
-    const fallbacks = [];
-    for (let i = 0; i < fallbacksCount; i++) {
-      fallbacks.push({ fallback: true, guid: 'fallback' + i, index: i });
-    }
+    /**
+     * 1. A fallback item has the same shape as a contact item, with an additional
+     * field `customAnimation`.
+     * 2. Both fallbacks and contacts are represented with <contact-element>
+     * 3. We load more contacts when user scrolls to the end of the list
+     * (listen for `rangechange`)
+     */
 
-    // Make a copy of the fallbacks.
-    const items = fallbacks.slice();
-
-    const nodePool = {
-      'fallback-element': [],
-      'contact-element': []
-    };
+    const dataSource = new ContactDataSource();
     const virtualList = document.querySelector('virtual-list');
-    Object.assign(virtualList, {
-      newChild(contact) {
-        const type = contact.fallback ? 'fallback-element' : 'contact-element';
-        return nodePool[type].pop() || document.createElement(type);
-      },
-      updateChild(element, contact) {
-        if (contact.fallback) {
-          element.textContent = '... Loading ...';
-          element.style.animationDelay = (50 * contact.index) + 'ms';
-        } else {
-          element.contact = contact;
-        }
-      },
-      recycleChild(element) {
-        nodePool[element.localName].push(element);
-      },
-      itemKey(contact) {
-        return contact.guid;
-      },
-      items,
+    const fallbacks = getFallbacks(virtualList.offsetHeight);
+    let firstFallbackIndex = 0;
+    let lastVisibleIndex = -1;
+
+    virtualList.newChild = (contact) => document.createElement('contact-element');
+    virtualList.updateChild = (element, contact) => {
+      element.style.animation = contact.customAnimation;
+      element.contact = contact;
+    };
+    // Start with fallbacks.
+    virtualList.items = [...fallbacks];
+
+    virtualList.addEventListener('rangechange', (range) => {
+      lastVisibleIndex = range.last;
+      if (lastVisibleIndex >= firstFallbackIndex) {
+        loadMore();
+      }
     });
 
-    let delayMs = 1000;
-    let isLoading = false;
-    let allContacts = null;
-    loadMore();
-
-    window.updateDelay = updateDelay;
-
     async function loadMore() {
-      if (isLoading) return;
-      isLoading = true;
-
-      virtualList.removeEventListener('rangechange', onRangechange);
-
-      const newContacts = await getContacts();
-
-      const i = items.length - fallbacksCount;
-      if (newContacts.length) {
-        // Keep fallbacks, insert newContacts.
-        items.splice(i, 0, ...newContacts);
-        virtualList.addEventListener('rangechange', onRangechange);
+      if (dataSource.loading || dataSource.loadedAll) return;
+      // Load 10x contacts so user has room to scroll once they're loaded.
+      const newContacts = await dataSource.getContacts(fallbacks.length * 10);
+      if (dataSource.loadedAll) {
+        virtualList.items.splice(firstFallbackIndex, fallbacks.length, ...newContacts);
+        firstFallbackIndex = Infinity;
       } else {
-        // Loaded all contacts! Remove fallbacks.
-        items.splice(i, fallbacksCount);
+        virtualList.items.splice(firstFallbackIndex, 0, ...newContacts);
+        firstFallbackIndex += newContacts.length;
       }
       virtualList.requestReset();
-
-      isLoading = false;
-    }
-
-    async function getContacts() {
-      if (!allContacts) {
-        allContacts = await fetch('contacts/contacts.json').then(resp => resp.json());
-      }
-      // Simulate slow server load...
-      await new Promise(resolve => setTimeout(resolve, delayMs));
-      return allContacts.splice(0, fallbacksCount);
-    }
-
-    function onRangechange(range) {
-      if (range.last > items.length - fallbacksCount) {
+      // We need to keep loading if the list is scrolled to the end.
+      if (lastVisibleIndex >= firstFallbackIndex) {
         loadMore();
       }
     }
 
-    function updateDelay(delayEl) {
-      delayMs = delayEl.valueAsNumber;
-      if (Number.isNaN(delayMs)) {
+    function getFallbacks(viewportHeight) {
+      // Compute how many <contact-element> can fit in the virtual-list height.
+      const elementHeight = 80;
+      // We want enough fallbacks to cover the viewport height.
+      const count = Math.ceil(viewportHeight / elementHeight);
+      const fallbacks = [];
+      for (let i = 0; i < count; i++) {
+        fallbacks.push({
+          name: 'Loading...',
+          image: null,
+          customAnimation: `inverse-color 1000ms ${i * 50}ms infinite`,
+        });
+      }
+      return fallbacks;
+    }
+
+    window.updateDelay = function updateDelay(delayEl) {
+      let delay = delayEl.valueAsNumber;
+      if (Number.isNaN(delay)) {
         // Default.
-        delayMs = 1000;
+        delay = 1000;
       } else {
         // Force min/max.
-        delayMs = Math.max(
+        delay = Math.max(
           Number.parseInt(delayEl.min),
-          Math.min(delayMs, Number.parseInt(delayEl.max))
+          Math.min(delay, Number.parseInt(delayEl.max))
         );
       }
-      delayEl.value = delayMs;
+      delayEl.value = delay;
+      dataSource.delay = delay;
     };
   </script>
 </body>

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -62,49 +62,42 @@
 
     const dataSource = new ContactDataSource();
     const virtualList = document.querySelector('virtual-list');
-    const fallbacks = getFallbacks({
-      elementHeight: 80,
-      viewportHeight: virtualList.offsetHeight
-    });
-    let firstFallbackIndex = 0;
-    let lastVisibleIndex = -1;
 
     virtualList.newChild = (contact) => document.createElement('contact-element');
     virtualList.updateChild = (element, contact) => {
       element.style.animation = contact.customAnimation;
       element.contact = contact;
     };
-    // Start with fallbacks.
-    virtualList.items = [...fallbacks];
 
+    // Start with fallbacks, generate enough to cover the viewport height.
+    const fallbacksCount = Math.ceil(virtualList.offsetHeight / 80);
+    virtualList.items = getFallbacks(fallbacksCount);
+
+    // Keep track of first fallback index to know when we need to load more contacts.
+    let firstFallbackIndex = 0;
     virtualList.addEventListener('rangechange', (range) => {
-      lastVisibleIndex = range.last;
-      if (lastVisibleIndex >= firstFallbackIndex) {
+      if (range.last >= firstFallbackIndex) {
         loadMore();
       }
     });
 
     async function loadMore() {
       if (dataSource.loading || dataSource.loadedAll) return;
-      // Load 10x contacts so user has room to scroll once they're loaded.
-      const newContacts = await dataSource.getContacts(fallbacks.length * 10);
+      // Load 5x contacts so user has room to scroll once they're loaded.
+      const newContacts = await dataSource.getContacts(fallbacksCount * 5);
       if (dataSource.loadedAll) {
-        virtualList.items.splice(firstFallbackIndex, fallbacks.length, ...newContacts);
+        // Remove fallbacks.
+        virtualList.items.splice(firstFallbackIndex, fallbacksCount, ...newContacts);
         firstFallbackIndex = Infinity;
       } else {
+        // Insert new contacts while keeping fallbacks at the end of the list.
         virtualList.items.splice(firstFallbackIndex, 0, ...newContacts);
         firstFallbackIndex += newContacts.length;
       }
       virtualList.requestReset();
-      // We need to keep loading if the list is scrolled to the end.
-      if (lastVisibleIndex >= firstFallbackIndex) {
-        loadMore();
-      }
     }
 
-    function getFallbacks({ elementHeight, viewportHeight }) {
-      // We want enough fallbacks to cover the viewport height.
-      const count = Math.ceil(viewportHeight / elementHeight);
+    function getFallbacks(count) {
       const fallbacks = [];
       for (let i = 0; i < count; i++) {
         fallbacks.push({

--- a/demo/sorting.html
+++ b/demo/sorting.html
@@ -10,11 +10,6 @@
       max-width: 600px;
       margin: 10px auto;
     }
-
-    contact-element {
-      will-change: transform;
-      transition: transform 200ms ease-in-out;
-    }
   </style>
 </head>
 
@@ -29,11 +24,13 @@
 
   <script type="module">
     import '../virtual-list-element.js';
+    import './contacts/contact-element.js';
 
     const virtualList = document.querySelector('virtual-list');
 
     virtualList.newChild = (contact) => {
       const element = document.createElement('contact-element');
+      element.setAttribute('sortable', '');
       element.addEventListener('moveup', (event) => moveContact(event.target.contact, -1));
       element.addEventListener('movedown', (event) => moveContact(event.target.contact, 1));
       return element;
@@ -56,77 +53,6 @@
     window.toggleItemKey = function toggleItemKey(useGuid) {
       virtualList.itemKey = useGuid ? (contact) => contact.guid : null;
     };
-  </script>
-
-  <script type="module">
-    class ContactElement extends HTMLElement {
-      connectedCallback() {
-        if (this.shadowRoot) {
-          return;
-        }
-        this.attachShadow({ mode: 'open' }).innerHTML = `
-<style>
-  :host {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    padding: 1rem 0;
-    border-bottom: 1px solid #eee;
-  }
-  img {
-    width: 50px;
-    height: 50px;
-    margin-right: 15px;
-    border-radius: 50%;
-    background-color: lightgray;
-  }
-  label {
-    width: 100%;
-    flex: 1;
-  }
-  button {
-    background-color: transparent;
-    border: none;
-    outline: none;
-  }
-</style>
-<img id="img">
-<label id="label"></label>
-<span id="counter"></span>
-<button id="up">🔼</button>
-<button id="down">🔽</button>`;
-
-        this._img = this.shadowRoot.querySelector('#img');
-        this._label = this.shadowRoot.querySelector('label');
-        this._counter = this.shadowRoot.querySelector('#counter');
-        this._renderCount = 0;
-
-        const up = this.shadowRoot.querySelector('#up');
-        up.addEventListener('click', () => this.dispatchEvent(new Event('moveup')));
-        const down = this.shadowRoot.querySelector('#down');
-        down.addEventListener('click', () => this.dispatchEvent(new Event('movedown')));
-
-        this.contact && this._render();
-      }
-      get contact() {
-        return this._contact;
-      }
-      set contact(contact) {
-        if (contact !== this._contact) {
-          this._contact = contact;
-          this._render();
-        }
-      }
-      _render() {
-        if (!this.shadowRoot) return;
-        const contact = this.contact || {};
-        this._img.src = contact.image;
-        this._label.textContent = contact.name;
-        this._label.style.color = contact.color;
-        this._counter.textContent = `render count: ${++this._renderCount}`;
-      }
-    }
-    customElements.define('contact-element', ContactElement);
   </script>
 </body>
 

--- a/virtual-list.js
+++ b/virtual-list.js
@@ -347,7 +347,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
    */
   _notifyStable() {
     const {first, num} = this;
-    const last = first + num;
+    const last = first + num - 1;
     this._container.dispatchEvent(
         new RangeChangeEvent('rangechange', {first, last}));
   }


### PR DESCRIPTION
Fixes #44 by implemeting an example with fallback UI elements
Moved `<contact-element>` into its own file, and added a `sortable` attribute which will display render count and up/down buttons.

##  fallback.html demo

![fallback](https://user-images.githubusercontent.com/6173664/39555394-e6aac584-4e2d-11e8-9eb1-b3b925dcddea.gif)


## bugfixes

While implementing the demo, I found and fixed 2 bugs:
- the value of `last` provided in `rangechange` was offset of -1 
- there might be a race condition when measuring children: measurement is done 1 microtask after `_render()`, and `_render()` is throttled of a microtask, so it might be that 2 consecutive `_render()` might affect the measurement (e.g. the 2nd render hides some children, and the 1st _measureChildren would memoize a 0x0 rect)
<img width="559" alt="screen shot 2018-05-04 at 11 59 37 am" src="https://user-images.githubusercontent.com/6173664/39647192-d39b6dd4-4f92-11e8-94e9-d9bd95dfe10b.png">
^ to fix this, we debounce _measureCallback