### PR TITLE
Remove default width

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ list.addEventListener('rangechange', (event) => {
 
 ### Scrolling
 
-`<virtual-list>` needs to be sized in order to determine how many items should be rendered. Its default size is 300px × 150px, similar to [CSS inline replaced elements](https://www.w3.org/TR/CSS2/visudet.html#inline-replaced-width) like images and iframes.
+`<virtual-list>` needs to be sized in order to determine how many items should be rendered. Its default height is 150px, similar to [CSS inline replaced elements](https://www.w3.org/TR/CSS2/visudet.html#inline-replaced-height) like images and iframes.
 
 Main document scrolling will be achievable through [`document.rootScroller`](https://github.com/bokand/root-scroller)
 ```html

--- a/demo/html-spec/html-spec-viewer.js
+++ b/demo/html-spec/html-spec-viewer.js
@@ -15,7 +15,6 @@ class HTMLSpecViewer extends VirtualListElement {
     right: 0px;
     bottom: 0px;
     padding: 8px;
-    width: auto;
     height: auto;
   }`;
       this.shadowRoot.appendChild(style);

--- a/demo/sorting.html
+++ b/demo/sorting.html
@@ -8,13 +8,17 @@
     body {
       font-family: Roboto, Helvetica, sans-serif;
       max-width: 600px;
-      margin: 10px auto;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+    }
+
+    label {
+      margin: 10px 0;
     }
 
     virtual-list {
-      width: 100%;
-      height: 50vh;
-      margin: 10px 0;
+      flex: 1;
       border-top: 2px solid #eee;
       border-bottom: 2px solid #eee;
     }

--- a/virtual-list-element.js
+++ b/virtual-list-element.js
@@ -51,10 +51,10 @@ export class VirtualListElement extends HTMLElement {
   }
   :host(:not([layout])) ::slotted(*), 
   :host([layout=vertical]) ::slotted(*) {
-    max-width: 100%;
+    width: 100%;
   }
   :host([layout=horizontal]) ::slotted(*) {
-    max-height: 100%;
+    height: 100%;
   }
 </style>
 <slot></slot>`;

--- a/virtual-list-element.js
+++ b/virtual-list-element.js
@@ -46,7 +46,6 @@ export class VirtualListElement extends HTMLElement {
     display: block;
     position: relative;
     contain: strict;
-    width: 300px;
     height: 150px;
     overflow: auto;
   }


### PR DESCRIPTION
Fixes #53 by removing the default width and leveraging the `display: block` behavior.
We still require a default height.

Also, set width/height instead of max-width/max-height for distributed content, as we expect the children to occupy the full width of a vertical list, and full height of a horizontal list. For grid lists we expect each child to be sized.