### PR TITLE
contacts/lit-html/ ensure start/end marker comment placement 

### DIFF
--- a/demo/contacts/lit-html/contacts.js
+++ b/demo/contacts/lit-html/contacts.js
@@ -1,6 +1,6 @@
 import {list} from '../../../lit-html/lit-list.js';
 import {html, render} from '../../../node_modules/lit-html/lib/lit-extended.js';
-import {itemType, Sample as BaseSample} from '../contacts.js';
+import {itemType, Sample as BaseSample, strip} from '../contacts.js';
 
 export class Sample extends BaseSample {
   _setUp() {

--- a/demo/contacts/lit-html/contacts.js
+++ b/demo/contacts/lit-html/contacts.js
@@ -17,7 +17,7 @@ export class Sample extends BaseSample {
                             contenteditable="true"
                             on-focus="${e => this._scrollToFocused(e)}"
                             on-blur="${
-            e => this._commitChange(idx, 'longText', e.target.textContent)}"
+            e => this._commitChange(idx, 'longText', e.target)}"
                         >
                             ${item.longText}
                         </p>
@@ -28,6 +28,17 @@ export class Sample extends BaseSample {
                     ${item.title}
                 </div>`;
     };
+  }
+
+  _commitChange(idx, prop, el) {
+    if (idx === -1)
+      return;
+    // Restore old value, lit-html will handle the update
+    // https://github.com/Polymer/lit-html/issues/316
+    const newVal = strip(el.textContent);
+    const prevVal = strip(this.items[idx][prop]);
+    el.textContent = prevVal;
+    super._commitChange(idx, prop, newVal);
   }
 
   render() {

--- a/demo/contacts/lit-html/contacts.js
+++ b/demo/contacts/lit-html/contacts.js
@@ -1,12 +1,15 @@
 import {list} from '../../../lit-html/lit-list.js';
 import {html, render} from '../../../node_modules/lit-html/lib/lit-extended.js';
-import {itemType, Sample as BaseSample, strip} from '../contacts.js';
+import {itemType, Sample as BaseSample} from '../contacts.js';
 
 export class Sample extends BaseSample {
   _setUp() {
     this.template = (item, idx) => {
       const type = itemType(item);
       if (type === 'contact') {
+        // NOTE(valdrin): don't add spaces in `<p contenteditable>` so
+        // lit-html can place its delimiter comments
+        // https://github.com/Polymer/lit-html/issues/316
         return html`
                     <div
                         style="padding: 10px; border-bottom: 1px solid #CCC; width: 100%; box-sizing: border-box;"
@@ -17,10 +20,8 @@ export class Sample extends BaseSample {
                             contenteditable="true"
                             on-focus="${e => this._scrollToFocused(e)}"
                             on-blur="${
-            e => this._commitChange(idx, 'longText', e.target)}"
-                        >
-                            ${item.longText}
-                        </p>
+            e => this._commitChange(idx, 'longText', e.target.textContent)}"
+                        >${item.longText}</p>
                     </div>`;
       }
       return html`
@@ -28,17 +29,6 @@ export class Sample extends BaseSample {
                     ${item.title}
                 </div>`;
     };
-  }
-
-  _commitChange(idx, prop, el) {
-    if (idx === -1)
-      return;
-    // Restore old value, lit-html will handle the update
-    // https://github.com/Polymer/lit-html/issues/316
-    const newVal = strip(el.textContent);
-    const prevVal = strip(this.items[idx][prop]);
-    el.textContent = prevVal;
-    super._commitChange(idx, prop, newVal);
   }
 
   render() {

--- a/demo/contacts/lit-html/contacts.js
+++ b/demo/contacts/lit-html/contacts.js
@@ -17,10 +17,10 @@ export class Sample extends BaseSample {
                     >
                         <b>#${item.index} - ${item.first} ${item.last}</b>
                         <p
-                            contenteditable="true"
+                            contenteditable
                             on-focus="${e => this._scrollToFocused(e)}"
                             on-blur="${
-            e => this._commitChange(idx, 'longText', e.target.textContent)}"
+            e => this._commitChange(idx, 'longText', e.target)}"
                         >${item.longText}</p>
                     </div>`;
       }
@@ -29,6 +29,24 @@ export class Sample extends BaseSample {
                     ${item.title}
                 </div>`;
     };
+  }
+
+  _commitChange(idx, prop, el) {
+    // NOTE(valdrin): ensure lit-html marker comments are always at the right
+    // place. When user deletes all the content and then writes, the new content
+    // goes as the first child. Likewise when the user hits the Return key, new
+    // content is wrapped in a <div>.
+    let startMarker = el.firstChild;
+    while (startMarker.nodeType !== Node.COMMENT_NODE) {
+      startMarker = startMarker.nextSibling;
+    }
+    el.insertBefore(startMarker, el.firstChild);
+    let endMarker = el.lastChild;
+    while (endMarker.nodeType !== Node.COMMENT_NODE) {
+      endMarker = endMarker.previousSibling;
+    }
+    el.appendChild(endMarker);
+    super._commitChange(idx, prop, el.textContent);
   }
 
   render() {


### PR DESCRIPTION
Fixes #39 by ensuring that there are no text nodes in `<p contenteditable>` and that we always place start/end marker comments before committing the change